### PR TITLE
Allow passing custom headers for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## [0.2.1] - 2021-07-01
+- Added ability to pass custom headers in requests.
+
 ## [0.2.0] - 2021-03-15
 
 - Add null-safety

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -115,7 +115,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -176,7 +176,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/google_geocoding.dart
+++ b/lib/google_geocoding.dart
@@ -21,7 +21,13 @@ class GoogleGeocoding {
   final String apiKEY;
   late Geocoding geocoding;
 
-  GoogleGeocoding(this.apiKEY) {
-    this.geocoding = Geocoding(apiKEY);
+  /// Optional headers to pass on each request
+  final Map<String, String> headers;
+
+  GoogleGeocoding(
+    this.apiKEY, {
+    this.headers = const {},
+  }) {
+    this.geocoding = Geocoding(apiKEY, headers);
   }
 }

--- a/lib/src/geocoding/geocoding.dart
+++ b/lib/src/geocoding/geocoding.dart
@@ -9,8 +9,9 @@ class Geocoding {
   final _authority = 'maps.googleapis.com';
   final _unencodedPath = 'maps/api/geocode/json';
   final String apiKEY;
+  final Map<String, String> headers;
 
-  Geocoding(this.apiKEY);
+  Geocoding(this.apiKEY, this.headers);
 
   /// Geocoding is the process of converting addresses (like a street address) into geographic coordinates (like latitude and longitude),
   /// which you can use to place markers on a map, or position the map.
@@ -56,7 +57,7 @@ class Geocoding {
       region,
     );
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return GeocodingResponse.parseGeocodingResponse(response);
     }
@@ -104,7 +105,7 @@ class Geocoding {
       locationType,
     );
     var uri = Uri.https(_authority, _unencodedPath, queryParameters);
-    var response = await NetworkUtility.fetchUrl(uri);
+    var response = await NetworkUtility.fetchUrl(uri, headers: headers);
     if (response != null) {
       return GeocodingResponse.parseGeocodingResponse(response);
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_geocoding
 description: A new Flutter package for handle google geocoding api that geocoding and reverse geocoding requests are available
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/bazrafkan/google_geocoding
 
 environment:


### PR DESCRIPTION
Same deal from https://github.com/bazrafkan/google_place/pull/27

Required to use platform-specific API keys where you must provide the following headers:

```dart
    final headers = <String, String>{
      if (defaultTargetPlatform == TargetPlatform.iOS)
        'x-ios-bundle-identifier': Env().bundleIdentifier, // com.my.app
      if (defaultTargetPlatform == TargetPlatform.android) ...{
        'x-android-package': Env().bundleIdentifier, // com.my.app
        'x-android-cert': Env().ANDROID_SIGNING_KEY_SHA1, // signing key used to build/publish the app
      }
    };
```
